### PR TITLE
Potential fix for code scanning alert no. 79: Reflected cross-site scripting

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -134,7 +134,8 @@
     "validate.js": "0.13.1",
     "worker-farm": "1.7.0",
     "xml2js": "0.6.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "xss": "^1.0.15"
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",

--- a/packages/server/src/api/controllers/metadata.ts
+++ b/packages/server/src/api/controllers/metadata.ts
@@ -1,6 +1,7 @@
 import { generateMetadataID } from "../../db/utils"
 import { saveEntityMetadata, deleteEntityMetadata } from "../../utilities"
 import { context } from "@budibase/backend-core"
+import xss from "xss"
 import {
   UserCtx,
   MetadataType,
@@ -24,7 +25,8 @@ export async function saveMetadata(
   if (type === MetadataType.AUTOMATION_TEST_HISTORY) {
     ctx.throw(400, "Cannot save automation history type")
   }
-  ctx.body = await saveEntityMetadata(type, entityId, ctx.request.body)
+  const sanitizedBody = xss(ctx.request.body)
+  ctx.body = await saveEntityMetadata(type, entityId, sanitizedBody)
 }
 
 export async function deleteMetadata(


### PR DESCRIPTION
Potential fix for [https://github.com/2ai-cx/budibase/security/code-scanning/79](https://github.com/2ai-cx/budibase/security/code-scanning/79)

To fix the problem, we need to ensure that the user-provided data in `ctx.request.body` is properly sanitized before it is passed to the `saveEntityMetadata` function. This can be achieved by using a library like `xss` to sanitize the input data. The best way to fix this without changing existing functionality is to sanitize the `ctx.request.body` before passing it to the `saveEntityMetadata` function.

1. Install the `xss` library to sanitize the input data.
2. Import the `xss` library in the file.
3. Sanitize the `ctx.request.body` before passing it to the `saveEntityMetadata` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
