### PR TITLE
Potential fix for code scanning alert no. 49: Prototype-polluting assignment

### DIFF
--- a/packages/server/src/sdk/app/tables/getters.ts
+++ b/packages/server/src/sdk/app/tables/getters.ts
@@ -18,10 +18,21 @@ import sdk from "../../../sdk"
 import { ensureQueryUISet } from "../views/utils"
 import { isV2 } from "../views"
 
+function sanitizeTable(table: Table): Table {
+  const forbiddenKeys = ["__proto__", "constructor", "prototype"];
+  for (const key of forbiddenKeys) {
+    if (key in table) {
+      delete table[key];
+    }
+  }
+  return table;
+}
+
 export async function processTable(table: Table): Promise<Table> {
   if (!table) {
     return table
   }
+  table = sanitizeTable(table);
 
   table = { ...table }
   if (table.views) {
@@ -101,7 +112,8 @@ export async function getExternalTable(
   if (!entities[tableName]) {
     throw new Error(`Unable to find table named "${tableName}"`)
   }
-  const table = await processTable(entities[tableName])
+  let table = await processTable(entities[tableName])
+  table = sanitizeTable(table);
   if (!table.sourceId) {
     table.sourceId = datasourceId
   }


### PR DESCRIPTION
Potential fix for [https://github.com/2ai-cx/budibase/security/code-scanning/49](https://github.com/2ai-cx/budibase/security/code-scanning/49)

To fix the prototype pollution vulnerability, we need to ensure that the `table` object does not contain any properties that could lead to prototype pollution, such as `__proto__`, `constructor`, or `prototype`. We can achieve this by using a prototype-less object created with `Object.create(null)` or by explicitly checking and rejecting such properties.

The best way to fix the problem without changing existing functionality is to validate the `table` object before assigning any properties to it. We will add a function to sanitize the `table` object and use it before the assignment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
